### PR TITLE
feat: Call `showSection(null)` when the URL hash does not start with …

### DIFF
--- a/articles.html
+++ b/articles.html
@@ -320,6 +320,8 @@
           if (hash.startsWith('#section-')) {
             const sectionId = hash.substring(1);
             showSection(sectionId);
+          } else {
+            showSection(null);
           }
         }
       }


### PR DESCRIPTION
fix accordian behavior
good enough for this issue, but will open other Accordian issues (back button etc)
Fixes #23